### PR TITLE
Fix crashes and add restart/score

### DIFF
--- a/app/src/main/java/com/example/touchlessui/GameView.kt
+++ b/app/src/main/java/com/example/touchlessui/GameView.kt
@@ -77,7 +77,7 @@ class GameView(context: Context, attrs: AttributeSet) : SurfaceView(context, att
   fun gameOver() {
     state = GameState.GAME_OVER
     isGameOver = true
-    onGameOver?.invoke()
+    post { onGameOver?.invoke() }
   }
 
   fun pauseGame() {
@@ -178,7 +178,13 @@ class GameView(context: Context, attrs: AttributeSet) : SurfaceView(context, att
       pipes.add(Pipe(context, spawnX.toInt(), height))
       spawnTicker = 0
     }
-    pipes.forEach { it.update() }
+    pipes.forEach {
+      it.update()
+      if (!it.isScored && it.scored(bird.x)) {
+        score++
+        it.isScored = true
+      }
+    }
     pipes.removeAll { it.isOffScreen() }
   }
 

--- a/app/src/main/java/com/example/touchlessui/MainActivity.kt
+++ b/app/src/main/java/com/example/touchlessui/MainActivity.kt
@@ -21,6 +21,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var ivReady: ImageView
     private lateinit var ivPause: ImageView
     private lateinit var ivPlay: ImageView
+    private lateinit var ivRestart: ImageView
     private lateinit var previewView: PreviewView
 
     private val cameraPermission =
@@ -35,6 +36,7 @@ class MainActivity : AppCompatActivity() {
         ivReady = findViewById(R.id.ivReady)
         ivPause = findViewById(R.id.ivPause)
         ivPlay = findViewById(R.id.ivPlay)
+        ivRestart = findViewById(R.id.ivRestart)
         previewView = findViewById(R.id.previewView)
 
         // DEBUG: show a toast whenever the overlay is tapped
@@ -43,6 +45,7 @@ class MainActivity : AppCompatActivity() {
             it.visibility = View.GONE        // hide the overlay
             ivPause.visibility = View.VISIBLE
             ivPlay.visibility = View.GONE
+            ivRestart.visibility = View.GONE
             gameView.startGame()            // switch to RUNNING
         }
 
@@ -50,6 +53,14 @@ class MainActivity : AppCompatActivity() {
             gameView.pauseGame()
             ivPause.visibility = View.GONE
             ivPlay.visibility = View.VISIBLE
+        }
+
+        ivRestart.setOnClickListener {
+            ivRestart.visibility = View.GONE
+            ivReady.visibility = View.GONE
+            ivPause.visibility = View.VISIBLE
+            ivPlay.visibility = View.GONE
+            gameView.startGame()
         }
 
         ivPlay.setOnClickListener {
@@ -61,7 +72,8 @@ class MainActivity : AppCompatActivity() {
         gameView.onGameOver = {
             ivPause.visibility = View.GONE
             ivPlay.visibility = View.GONE
-            ivReady.visibility = View.VISIBLE
+            ivReady.visibility = View.GONE
+            ivRestart.visibility = View.VISIBLE
         }
 
         // Request camera
@@ -92,6 +104,8 @@ class MainActivity : AppCompatActivity() {
                             if (gameView.isGameOver) {
                                 ivPause.visibility = View.VISIBLE
                                 ivPlay.visibility = View.GONE
+                                ivRestart.visibility = View.GONE
+                                ivReady.visibility = View.GONE
                                 gameView.startGame()
                             } else {
                                 Log.d("MainActivity", "Blink detected → flap()")

--- a/app/src/main/java/com/example/touchlessui/Pipe.kt
+++ b/app/src/main/java/com/example/touchlessui/Pipe.kt
@@ -17,6 +17,7 @@ class Pipe(context: Context, private val screenWidth: Int, private val screenHei
 
     // X position starts off-screen to the right
     var x = screenWidth.toFloat()
+    var isScored = false
     // Randomize center of gap between some margins
     private val centerY = Random.nextInt(gap, screenHeight - gap)
 


### PR DESCRIPTION
## Summary
- handle UI updates on game over on the main thread
- track pipe scoring and show current score
- add restart button overlay and start the game from it
- wire restart actions in `MainActivity`
- remove restart resource duplicates

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684daffb7f208324baeb32ed96dd7379